### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete string escaping or encoding

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -912,6 +912,7 @@ try {
               };
 
               let formattedText = text;
+              formattedText = formattedText.replace(/\\/g, '\\\\'); // Escape backslashes
               formattedText = formattedText.replace(/`/g, '\\`');   // Escape backticks
 
               const evaluatedText = eval("`" + formattedText + "`");


### PR DESCRIPTION
Potential fix for [https://github.com/palidintheonly/MonkeyBytes-App/security/code-scanning/3](https://github.com/palidintheonly/MonkeyBytes-App/security/code-scanning/3)

To fix the problem, we need to ensure that backslashes are also escaped in the input string. This can be done by adding an additional `replace` call to escape backslashes before escaping backticks. This ensures that all occurrences of backslashes are properly escaped, preventing any unintended behavior when the string is evaluated.

The best way to fix the problem without changing existing functionality is to modify the `formattedText` variable to escape backslashes before escaping backticks. This can be achieved by chaining another `replace` call to handle backslashes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
